### PR TITLE
Backend: Authorization Request Binding (Issue #48)

### DIFF
--- a/keycard-ui/qml/AuthorizationScreen.qml
+++ b/keycard-ui/qml/AuthorizationScreen.qml
@@ -6,12 +6,16 @@ FocusScope {
     id: root
     focus: true
 
-    signal approved()
-    signal declined()
+    signal approved(string authRequestId, string pin)
+    signal declined(string authRequestId)
 
-    property string moduleName: "Notes module"
-    property string domain: "notes_private"
-    property string path: "m/43'/60'/1581'/1437890605'/512438859'"
+    // Request data (must be set by parent)
+    property string authRequestId: ""
+    property string moduleName: ""
+    property string domain: ""
+    property string path: ""
+
+    // PIN entry
     property string pinValue: ""
     property int maxPinLength: 6
 
@@ -239,8 +243,8 @@ FocusScope {
                                 enabled: root.pinValue.length === root.maxPinLength
                                 cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                                 onClicked: {
-                                    console.log("Approve clicked, PIN:", root.pinValue)
-                                    root.approved()
+                                    console.log("Approve clicked, ID:", root.authRequestId, "PIN:", root.pinValue)
+                                    root.approved(root.authRequestId, root.pinValue)
                                 }
                             }
                         }
@@ -269,8 +273,8 @@ FocusScope {
                                 hoverEnabled: true
                                 cursorShape: Qt.PointingHandCursor
                                 onClicked: {
-                                    console.log("Decline clicked")
-                                    root.declined()
+                                    console.log("Decline clicked, ID:", root.authRequestId)
+                                    root.declined(root.authRequestId)
                                 }
                             }
                         }

--- a/keycard-ui/qml/Main.qml
+++ b/keycard-ui/qml/Main.qml
@@ -11,6 +11,9 @@ Rectangle {
     property string mode: "pin"
     property bool debugMode: false
 
+    // Current authorization request (when mode === "authorization")
+    property var currentAuthRequest: null
+
     // Keyboard shortcuts
     Keys.onPressed: (event) => {
         // Ctrl+D: Toggle debug mode
@@ -33,6 +36,16 @@ Rectangle {
             }
             event.accepted = true
         }
+        // Ctrl+A: Show mock authorization request (for testing)
+        else if (event.key === Qt.Key_A && (event.modifiers & Qt.ControlModifier)) {
+            showAuthorizationRequest(
+                "auth_req_001",
+                "notes",
+                "notes_private",
+                "m/43'/60'/1581'/1437890605'/512438859'"
+            )
+            event.accepted = true
+        }
     }
 
     focus: true  // Enable keyboard input
@@ -46,6 +59,17 @@ Rectangle {
         console.log("Locking session...")
         // TODO: Call backend lockSession()
         mode = "pin"
+    }
+
+    function showAuthorizationRequest(requestId, moduleName, domain, path) {
+        console.log("Showing authorization request:", requestId, moduleName, domain, path)
+        currentAuthRequest = {
+            id: requestId,
+            moduleName: moduleName,
+            domain: domain,
+            path: path
+        }
+        mode = "authorization"
     }
 
     // Production UI
@@ -73,18 +97,27 @@ Rectangle {
                 })
             }
             if (item && item.approved) {
-                item.approved.connect(function() {
-                    console.log("Authorization approved")
-                    // TODO: Call backend authorize() with PIN
+                item.approved.connect(function(authRequestId, pin) {
+                    console.log("Authorization approved, ID:", authRequestId, "PIN:", pin)
+                    // TODO (#49): Call backend authorize() with authRequestId and pin
+                    root.currentAuthRequest = null
                     root.mode = "dashboard"
                 })
             }
             if (item && item.declined) {
-                item.declined.connect(function() {
-                    console.log("Authorization declined")
-                    // TODO: Call backend decline()
+                item.declined.connect(function(authRequestId) {
+                    console.log("Authorization declined, ID:", authRequestId)
+                    // TODO (#49): Call backend decline() with authRequestId
+                    root.currentAuthRequest = null
                     root.mode = "dashboard"
                 })
+            }
+            // Set request data for authorization screen
+            if (item && item.authRequestId !== undefined && root.currentAuthRequest) {
+                item.authRequestId = root.currentAuthRequest.id
+                item.moduleName = root.currentAuthRequest.moduleName
+                item.domain = root.currentAuthRequest.domain
+                item.path = root.currentAuthRequest.path
             }
             // Give focus to loaded item
             if (item) {


### PR DESCRIPTION
## Summary

Wire authorization screen to real request objects and IDs. Removes hardcoded placeholder data.

Closes #48

## What Changed

**AuthorizationScreen.qml:**
- Added `authRequestId` property for tracking requests
- Removed hardcoded placeholder values (`moduleName`, `domain`, `path`)
- Updated signals: `approved(authRequestId, pin)` and `declined(authRequestId)`
- Log request ID with approval/decline actions

**Main.qml:**
- Added `currentAuthRequest` property to store active request
- Added `showAuthorizationRequest(id, module, domain, path)` function
- Updated signal handlers to receive and process authRequestId + PIN
- Set request data on AuthorizationScreen when loaded
- Added Ctrl+A shortcut for testing (shows mock request)

## Testing

✅ **Manual testing completed:**
1. Pressed Ctrl+A to trigger mock authorization request
2. Screen displayed correct data:
   - Module: "notes"
   - Domain: "notes_private"
   - Path: "m/43'/60'/1581'/1437890605'/512438859'"
3. Approve/Decline buttons work correctly
4. Request ID passed with signals

## What's Deferred

Backend API integration (Issue #49):
- Real `authorizeRequest(authRequestId, pin)` call
- Real `rejectRequest(authRequestId)` call  
- Backend event handling for incoming requests

## Dependencies

- Requires: #42 (UI shell) ✅ merged
- Blocks: #49 (backend API calls need request ID)

Ready for review!

---

Fergie: @Senty - request binding complete, ready for review!