### PR TITLE
Issue #70: Auto-close session after approval

### DIFF
--- a/keycard-core/src/plugin.cpp
+++ b/keycard-core/src/plugin.cpp
@@ -558,6 +558,10 @@ QString KeycardPlugin::authorizeRequest(const QString& authId, const QString& pi
     logActivity(QString("Key derived for module %1 following approved path %2").arg(moduleName, derivedPath), "success");
     logActivity(QString("Go back to %1 module to continue").arg(moduleName), "warning");
 
+    // Auto-close session after approval (Epic #55: no persistent session)
+    m_sessionState = SessionState::NoSession;
+    logActivity("Session closed", "success");
+
     QJsonObject result;
     result["authId"] = authId;
     result["status"] = "complete";


### PR DESCRIPTION
## Summary
- Reset session state to NoSession after successful key derivation
- Log "Session closed" (green) in activity log after approval

## Test plan
- [x] Dev build passes
- [x] Senty LGTM
- [x] Completed AuthRequests remain queryable via checkAuthStatus()

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)