### PR TITLE
Security: one-read-and-drop key semantics for #94

### DIFF
--- a/KEYCARD_API.md
+++ b/KEYCARD_API.md
@@ -200,9 +200,9 @@ Returns all pending authorization requests.
 
 ### authorizeRequest(authId, pin)
 
-Approve a pending request with the card PIN. Derives key on-card and auto-closes session.
+Approve a pending request with the card PIN. Derives key on-card and auto-closes session. The key is **not** returned in this response — retrieve it via a follow-up `checkAuthStatus(authId)` call (one-read-and-drop: the key is returned exactly once, then the request is wiped and removed).
 
-**Success:** `{ "authId": "...", "status": "complete", "key": "hex...", "message": "..." }`
+**Success:** `{ "authId": "...", "status": "complete", "message": "Authorization completed. Poll checkAuthStatus to retrieve key." }`
 **Wrong PIN:** `{ "authId": "...", "status": "retry", "remainingAttempts": N }` — no `error` field. The underlying `AuthRequest` stays `pending` on the consumer side.
 **Derivation error (after PIN verified):** `{ "authId": "...", "status": "retry" }` — no `error` field, no `remainingAttempts`. The underlying `AuthRequest` also stays `pending` on the consumer side.
 **Not found:** `{ "error": "Auth request not found or already completed" }`

--- a/docs/doc-packet-draft.md
+++ b/docs/doc-packet-draft.md
@@ -1,0 +1,129 @@
+# Doc-Packet Draft — Keycard for Basecamp
+
+Prepared for submission to [logos-co/logos-docs](https://github.com/logos-co/logos-docs/issues/new?template=doc-packet.yml).
+
+Tracking issue: [#104](https://github.com/xAlisher/keycard-basecamp/issues/104)
+
+---
+
+## 1. Outcome and Purpose
+
+**What the user achieves (one sentence):**
+Add hardware-backed key derivation to any Basecamp module using a single API call and a shared approval UI.
+
+**Why it matters:**
+Keycard gives every Basecamp module access to on-card BIP32 key derivation and PIN verification through one audited integration — no module needs its own PC/SC stack, PIN-lockout state machine, or smartcard UI. One module, many consumers.
+
+**Key components (2–5):**
+- `keycard-core` — Basecamp core module: PC/SC bridge, state machine, `requestAuth`/`checkAuthStatus` consumer API
+- `keycard-ui` — Basecamp UI plugin: shared approval panel (PIN entry, request approval/decline, activity log)
+- `KeycardAuth.qml` — drop-in QML component for consuming modules (handles polling, status, key delivery)
+- `keycard-qt` (vendored) — Qt wrapper around the Keycard applet APDU protocol
+
+---
+
+## 2. Scope
+
+**Repository:**
+https://github.com/xAlisher/keycard-basecamp — branch `master`
+
+**Runtime target:**
+Local (desktop Basecamp — Linux x86_64, AppImage distribution)
+
+**Prerequisites:**
+- Linux x86_64
+- Nix package manager (for build environment)
+- Logos Basecamp AppImage (`logos-app.AppImage`)
+- USB smartcard reader (tested with ACS ACR122U, Identiv uTrust)
+- Keycard smartcard (Status Keycard or compatible JavaCard applet)
+- `pcscd` service running (`sudo systemctl start pcscd`)
+
+---
+
+## 3. Happy Path
+
+```sh
+# 1. Clone and build
+git clone https://github.com/xAlisher/keycard-basecamp.git
+cd keycard-basecamp
+nix develop --command bash -c "cmake -B build -G Ninja -DCMAKE_BUILD_TYPE=Debug && cmake --build build"
+
+# 2. Install to Basecamp
+cmake --install build --prefix ~/.local/share/Logos/LogosApp
+
+# 3. Clear cache and launch
+rm -rf ~/.cache/Logos/LogosApp/qmlcache/*
+~/logos-app/logos-app.AppImage
+
+# 4. In Basecamp:
+#    - Open the Keycard debug panel (keycard-ui)
+#    - Insert smartcard into reader
+#    - Click "Discover Reader" → state changes to CARD_NOT_PRESENT
+#    - Click "Discover Card" → state changes to CARD_PRESENT
+#    - Enter PIN, click "Authorize" → state changes to AUTHORIZED
+#    - Enter a domain (e.g. "notes_encryption"), click "Derive Key" → key appears (hex)
+#    - Click "Close Session" → state changes to SESSION_CLOSED, key is wiped
+
+# 5. Consumer integration (from another module's QML):
+#    var result = logos.callModule("keycard", "requestAuth", ["my_domain", "my_module"])
+#    var authId = JSON.parse(result).authId
+#    // poll checkAuthStatus(authId) until status == "complete", then use response.key
+```
+
+---
+
+## 4. Verification
+
+**Success command:**
+```sh
+# After building + installing, verify the plugin is discovered by Basecamp
+ls ~/.local/share/Logos/LogosApp/plugins/keycard-core/plugin_metadata.json
+```
+
+**Expected result:**
+```sh
+# File exists and contains valid metadata:
+# {"name":"keycard-core","version":"0.1.0", ...}
+# AND in Basecamp, the Keycard debug panel loads and shows "READER_NOT_FOUND" initial state
+```
+
+---
+
+## 5. Configuration (optional)
+
+- `pcscd` must be running as a system service — Keycard uses the system's PC/SC daemon, not a bundled one
+- No environment variables or custom ports required
+- The LGX package must NOT bundle `libpcsclite.so` (breaks `pcscd` communication)
+
+---
+
+## 6. Known Issues / Failure Modes (optional)
+
+1. **Card blocked after 3 wrong PINs** — card enters permanent lockout until PUK recovery. No automated recovery in `keycard-basecamp`; standard Keycard tooling required.
+2. **`libpcsclite` accidentally bundled in LGX** — if the packaged plugin includes `libpcsclite.so`, `pcscd` communication breaks silently. Verify with `tar -tzf keycard-core.lgx | grep -i pcsclite` (must return nothing).
+3. **Derived keys persist in memory after read ([#94](https://github.com/xAlisher/keycard-basecamp/issues/94))** — `checkAuthStatus()` returns the same key on repeat calls; `closeSession()` does not wipe completed auth requests. Fix in progress.
+
+---
+
+## 7. Point of Contact
+
+<!-- TODO: fill with Alisher's handles -->
+- **GitHub:** @xAlisher
+- **Discord:** (TODO)
+
+---
+
+## 8. Additional Context (optional)
+
+**Existing docs:**
+- [JOURNEYS.md](../JOURNEYS.md) — product-level framing (user, developer, node operator journeys)
+- [KEYCARD_API.md](../KEYCARD_API.md) — complete API reference for consumers
+- [INTEGRATION_GUIDE.md](../INTEGRATION_GUIDE.md) — 5-minute developer quickstart
+- [SPEC.md](../SPEC.md) — state machine, security properties, method specifications
+
+**Security notes:**
+- PIN never leaves the card — verified on-chip
+- Key material derived on-card via BIP32, returned to host only after PIN verification
+- No persistent key storage — card must be present for every derivation
+- In-memory key cleanup after read is a known gap ([#94](https://github.com/xAlisher/keycard-basecamp/issues/94))
+- `sodium_memzero` used for key wiping; `SecureBuffer` RAII pattern for key material

--- a/docs/retro-log.md
+++ b/docs/retro-log.md
@@ -4,6 +4,27 @@ Post-merge retrospectives per `~/fieldcraft/protocols/wins-and-fails.md`.
 
 ---
 
+## Issue #94 — Key persistence fix (2026-04-10, in progress)
+
+### Process wins
+- Followed builder-auditor protocol: branch → implement → commit → push → GitHub handoff → tmux ping
+- Structured handoff comment with verified/not-verified sections and design questions for Senty
+
+### Process fails
+- **tmux-bridge messages typed but never submitted.** `tmux-bridge message` types text into the target pane but does NOT press Enter. All three messages to Senty sat in his input buffer unsubmitted. I assumed no output = success, never verified by reading the pane.
+  - **Root cause:** Did not understand that `tmux-bridge message` only types — it does not auto-submit. Must follow with `tmux-bridge keys <target> Enter`. Then did not verify delivery by reading the pane afterward.
+  - **Compounding error:** When Alisher flagged the first failure, I misdiagnosed it as a "read before message" prerequisite issue. I added a `read` call and retried, but still didn't press Enter and still didn't verify. Took a second correction from Alisher to identify the real problem.
+  - **Fix:** After every `tmux-bridge message`, immediately run `tmux-bridge keys <target> Enter`, then `tmux-bridge read <target> 5` to confirm the message was received and processed.
+- **Doc-packet draft committed on issue-94 branch.** Mixed unrelated work (docs/doc-packet-draft.md) into a security fix branch. Should have been on a separate branch or committed to master before branching.
+
+### Project lessons (added to docs/skills/lessons.md)
+- (pending — will add tmux-bridge read-before-message lesson after merge)
+
+### Feedback for Alisher
+- (none yet — review in progress)
+
+---
+
 <!-- Template:
 ## Epic #NN — Title (YYYY-MM-DD)
 

--- a/keycard-core/src/plugin.cpp
+++ b/keycard-core/src/plugin.cpp
@@ -8,6 +8,7 @@
 #include <QUuid>
 #include <QDateTime>
 #include <QDebug>
+#include <algorithm>
 #include <sodium.h>
 
 KeycardPlugin::KeycardPlugin(QObject* parent)
@@ -19,6 +20,10 @@ KeycardPlugin::KeycardPlugin(QObject* parent)
 
 KeycardPlugin::~KeycardPlugin()
 {
+    // Wipe all auth requests on unload
+    purgeCompletedRequests();
+    m_authRequests.clear();
+
     if (m_bridge) {
         m_bridge->stop();
         delete m_bridge;
@@ -332,6 +337,7 @@ QString KeycardPlugin::getState()
     if (cardGone && (m_sessionState == SessionState::Active || m_sessionState == SessionState::NoSession)) {
         qDebug() << "KeycardPlugin::getState() - card gone, clearing session state";
         m_sessionState = SessionState::NoSession;
+        purgeCompletedRequests();
     }
 
     // Session state takes precedence over bridge state (only if card still present)
@@ -353,6 +359,9 @@ QString KeycardPlugin::closeSession()
 
     // Reset session state (keep bridge running for future requests)
     m_sessionState = SessionState::NoSession;
+
+    // SECURITY: Wipe and remove all completed/consumed auth requests
+    purgeCompletedRequests();
 
     QJsonObject result;
     result["closed"] = true;
@@ -596,7 +605,7 @@ QString KeycardPlugin::requestAuth(const QString& domain, const QString& caller)
     request.status = "pending";
     request.timestamp = QDateTime::currentMSecsSinceEpoch();
 
-    m_authRequests.append(request);
+    m_authRequests.push_back(std::move(request));
 
     logActivity(QString("Module %1 is requesting access to domain %2").arg(caller, domain), "warning");
 
@@ -611,20 +620,29 @@ QString KeycardPlugin::requestAuth(const QString& domain, const QString& caller)
 
 QString KeycardPlugin::checkAuthStatus(const QString& authId)
 {
-    for (const auto& req : m_authRequests) {
+    for (size_t i = 0; i < m_authRequests.size(); ++i) {
+        auto& req = m_authRequests[i];
         if (req.id == authId) {
             QJsonObject result;
             result["authId"] = authId;
-            result["status"] = req.status;
             result["domain"] = req.domain;
             result["caller"] = req.caller;
 
             if (req.status == "complete") {
-                result["key"] = req.key;
+                // SECURITY: One-read-and-drop — return key exactly once,
+                // then wipe the SecureBuffer and remove the request.
+                result["status"] = "complete";
+                result["key"] = QString::fromUtf8(req.key.ref().toHex());
+                req.key.wipe();
+                m_loggedRequestIds.remove(authId);
+                m_authRequests.erase(m_authRequests.begin() + i);
+
+                return QJsonDocument(result).toJson(QJsonDocument::Compact);
             }
+
             // Only expose pending/complete/declined to calling modules
             // Wrong PIN / internal errors stay as "pending"
-
+            result["status"] = req.status;
             return QJsonDocument(result).toJson(QJsonDocument::Compact);
         }
     }
@@ -638,7 +656,7 @@ QString KeycardPlugin::getPendingAuths()
 {
     QJsonArray pending;
 
-    for (const auto& req : m_authRequests) {
+    for (auto& req : m_authRequests) {
         if (req.status == "pending") {
             QJsonObject obj;
             obj["authId"] = req.id;
@@ -722,9 +740,13 @@ QString KeycardPlugin::authorizeRequest(const QString& authId, const QString& pi
         return QJsonDocument(result).toJson(QJsonDocument::Compact);
     }
 
-    // Success - store legitimate hardware-derived key
+    // Success - store key in SecureBuffer (not QString)
     targetRequest->status = "complete";
-    targetRequest->key = keyResult.value("key").toString();
+    QString hexKey = keyResult.value("key").toString();
+    QByteArray keyBytes = QByteArray::fromHex(hexKey.toUtf8());
+    targetRequest->key = SecureBuffer(std::move(keyBytes));
+    // Wipe the intermediate QString hex — QByteArray was moved, but QString remains
+    sodium_memzero(hexKey.data(), hexKey.size() * sizeof(QChar));
 
     // Log authorization with domain and BIP32 path
     QString moduleName = targetRequest->caller;
@@ -740,11 +762,13 @@ QString KeycardPlugin::authorizeRequest(const QString& authId, const QString& pi
     logActivity("Session closed", "success");
     logActivity(QString("Go back to %1 module to continue").arg(moduleName), "warning");
 
+    // Return key to keycard-ui for immediate display — the consumer will
+    // read it once via checkAuthStatus, which wipes and removes the request.
     QJsonObject result;
     result["authId"] = authId;
     result["status"] = "complete";
     result["message"] = "Authorization completed successfully";
-    result["key"] = targetRequest->key;  // Return key immediately for UI
+    result["key"] = QString::fromUtf8(targetRequest->key.ref().toHex());
 
     addActivityToResponse(result);
     return QJsonDocument(result).toJson(QJsonDocument::Compact);
@@ -782,6 +806,24 @@ QString KeycardPlugin::rejectRequest(const QString& authId)
     result["message"] = "Authorization request declined by user";
 
     return QJsonDocument(result).toJson(QJsonDocument::Compact);
+}
+
+void KeycardPlugin::purgeCompletedRequests()
+{
+    // SECURITY: Wipe key material and remove completed/consumed requests.
+    // SecureBuffer destructor handles sodium_memzero via RAII,
+    // but we wipe explicitly for defense-in-depth.
+    for (auto& req : m_authRequests) {
+        if (req.status == "complete" || req.status == "consumed") {
+            req.key.wipe();
+            m_loggedRequestIds.remove(req.id);
+        }
+    }
+    auto it = std::remove_if(m_authRequests.begin(), m_authRequests.end(),
+        [](const AuthRequest& req) {
+            return req.status == "complete" || req.status == "consumed";
+        });
+    m_authRequests.erase(it, m_authRequests.end());
 }
 
 void KeycardPlugin::logActivity(const QString& message, const QString& level)

--- a/keycard-core/src/plugin.cpp
+++ b/keycard-core/src/plugin.cpp
@@ -632,7 +632,10 @@ QString KeycardPlugin::checkAuthStatus(const QString& authId)
                 // SECURITY: One-read-and-drop — return key exactly once,
                 // then wipe the SecureBuffer and remove the request.
                 result["status"] = "complete";
-                result["key"] = QString::fromUtf8(req.key.ref().toHex());
+                QByteArray keyHex = req.key.ref().toHex();
+                result["key"] = QString::fromUtf8(keyHex);
+                // Wipe the hex intermediate before it leaves scope
+                sodium_memzero(keyHex.data(), keyHex.size());
                 req.key.wipe();
                 m_loggedRequestIds.remove(authId);
                 m_authRequests.erase(m_authRequests.begin() + i);
@@ -724,7 +727,12 @@ QString KeycardPlugin::authorizeRequest(const QString& authId, const QString& pi
 
     // SECURITY: Derive key from hardware (only after PIN verified)
     QString domain = targetRequest->domain;
-    QJsonObject keyResult = QJsonDocument::fromJson(deriveKey(domain).toUtf8()).object();
+    QString deriveResponse = deriveKey(domain);
+    QByteArray deriveResponseUtf8 = deriveResponse.toUtf8();
+    QJsonObject keyResult = QJsonDocument::fromJson(deriveResponseUtf8).object();
+    // Wipe the raw JSON response bytes (contains key hex)
+    sodium_memzero(deriveResponseUtf8.data(), deriveResponseUtf8.size());
+    sodium_memzero(deriveResponse.data(), deriveResponse.size() * sizeof(QChar));
 
     if (keyResult.contains("error")) {
         if (m_bridge) m_bridge->setOperationInProgress(false);
@@ -740,17 +748,21 @@ QString KeycardPlugin::authorizeRequest(const QString& authId, const QString& pi
         return QJsonDocument(result).toJson(QJsonDocument::Compact);
     }
 
-    // Success - store key in SecureBuffer (not QString)
+    // SECURITY: Extract key from JSON, store in SecureBuffer, wipe all intermediates.
     targetRequest->status = "complete";
     QString hexKey = keyResult.value("key").toString();
-    QByteArray keyBytes = QByteArray::fromHex(hexKey.toUtf8());
+    QByteArray hexKeyUtf8 = hexKey.toUtf8();
+    QByteArray keyBytes = QByteArray::fromHex(hexKeyUtf8);
     targetRequest->key = SecureBuffer(std::move(keyBytes));
-    // Wipe the intermediate QString hex — QByteArray was moved, but QString remains
+    // Wipe all intermediate buffers that touched key material
+    sodium_memzero(hexKeyUtf8.data(), hexKeyUtf8.size());
     sodium_memzero(hexKey.data(), hexKey.size() * sizeof(QChar));
 
-    // Log authorization with domain and BIP32 path
+    // Extract non-secret fields before wiping the JSON object's key entry
     QString moduleName = targetRequest->caller;
     QString derivedPath = keyResult.value("path").toString();
+    // Remove key from the parsed JSON object so it doesn't linger
+    keyResult.remove("key");
     logActivity(QString("Request from %1 approved for domain %2").arg(moduleName, domain), "success");
     logActivity(QString("Key derived for module %1 following approved path %2").arg(moduleName, derivedPath), "success");
 
@@ -762,13 +774,12 @@ QString KeycardPlugin::authorizeRequest(const QString& authId, const QString& pi
     logActivity("Session closed", "success");
     logActivity(QString("Go back to %1 module to continue").arg(moduleName), "warning");
 
-    // Return key to keycard-ui for immediate display — the consumer will
-    // read it once via checkAuthStatus, which wipes and removes the request.
+    // SECURITY: Do NOT return key here. The only path that hands out
+    // the derived key is checkAuthStatus() — one-read-and-drop.
     QJsonObject result;
     result["authId"] = authId;
     result["status"] = "complete";
-    result["message"] = "Authorization completed successfully";
-    result["key"] = QString::fromUtf8(targetRequest->key.ref().toHex());
+    result["message"] = "Authorization completed. Poll checkAuthStatus to retrieve key.";
 
     addActivityToResponse(result);
     return QJsonDocument(result).toJson(QJsonDocument::Compact);

--- a/keycard-core/src/plugin.h
+++ b/keycard-core/src/plugin.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "KeycardBridge.h"
+#include "secure_buffer.h"
 #include <QObject>
 #include <QString>
 #include <QVariantList>
 #include <QDateTime>
 #include <QSet>
+#include <vector>
 #include <module_lib/interface.h>
 
 class KeycardPlugin : public QObject, public PluginInterface
@@ -58,11 +60,20 @@ private:
         QString id;
         QString domain;
         QString caller;
-        QString status;  // "pending", "complete", "failed"
-        QString key;     // Result key (if complete)
+        QString status;  // "pending", "complete", "consumed", "failed"
+        SecureBuffer key; // Result key (if complete) — wiped after first read
         QString error;   // Error message (if failed)
         qint64 timestamp;
+
+        // Move-only (SecureBuffer is non-copyable)
+        AuthRequest() = default;
+        AuthRequest(AuthRequest&&) = default;
+        AuthRequest& operator=(AuthRequest&&) = default;
+        AuthRequest(const AuthRequest&) = delete;
+        AuthRequest& operator=(const AuthRequest&) = delete;
     };
+
+    void purgeCompletedRequests();
 
     QString mapBridgeStateToSpec(KeycardBridge::State state);
     void logActivity(const QString& message, const QString& level = "info");
@@ -76,7 +87,7 @@ private:
 private:
     KeycardBridge* m_bridge = nullptr;
     SessionState m_sessionState = SessionState::NoSession;
-    QList<AuthRequest> m_authRequests;
+    std::vector<AuthRequest> m_authRequests;
 
     // Activity log queue (for QML)
     struct ActivityEntry {

--- a/keycard-core/src/secure_buffer.h
+++ b/keycard-core/src/secure_buffer.h
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <QByteArray>
+#include <sodium.h>
+#include <utility>
+
+// RAII wrapper around QByteArray that calls sodium_memzero on destruction.
+// Use for any secret material: keys, plaintext passwords, derived bytes.
+// Ported from logos-notes/src/core/SecureBuffer.h
+class SecureBuffer
+{
+public:
+    SecureBuffer() = default;
+
+    explicit SecureBuffer(int size)
+        : m_data(size, '\0')
+    {}
+
+    // Take ownership of existing bytes (zeroes the source).
+    explicit SecureBuffer(QByteArray &&src) noexcept
+        : m_data(std::move(src))
+    {}
+
+    // Copy from QByteArray — caller should zero their copy if needed.
+    explicit SecureBuffer(const QByteArray &src)
+        : m_data(src)
+    {}
+
+    ~SecureBuffer() { wipe(); }
+
+    // Move OK — source is left empty.
+    SecureBuffer(SecureBuffer &&other) noexcept
+        : m_data(std::move(other.m_data))
+    {}
+
+    SecureBuffer &operator=(SecureBuffer &&other) noexcept
+    {
+        if (this != &other) {
+            wipe();
+            m_data = std::move(other.m_data);
+        }
+        return *this;
+    }
+
+    // No copy — forces explicit intent.
+    SecureBuffer(const SecureBuffer &) = delete;
+    SecureBuffer &operator=(const SecureBuffer &) = delete;
+
+    // Wipe and release.
+    void wipe()
+    {
+        if (!m_data.isEmpty()) {
+            sodium_memzero(m_data.data(), m_data.size());
+            m_data.clear();
+        }
+    }
+
+    // Access
+    char       *data()       { return m_data.data(); }
+    const char *constData() const { return m_data.constData(); }
+    int         size()  const { return m_data.size(); }
+    bool        isEmpty() const { return m_data.isEmpty(); }
+    void        resize(int n) { m_data.resize(n, '\0'); }
+
+    // Convenience: return a copy as QByteArray (caller owns the copy).
+    QByteArray toByteArray() const { return m_data; }
+
+    // Convert to hex string, then wipe the buffer. One-shot consumption.
+    QString toHexAndWipe()
+    {
+        QString hex = QString::fromUtf8(m_data.toHex());
+        wipe();
+        return hex;
+    }
+
+    // Allow implicit read as const QByteArray& for passing to libsodium/Qt APIs.
+    const QByteArray &ref() const { return m_data; }
+
+private:
+    QByteArray m_data;
+};

--- a/keycard-ui/qml/DebugPanel.qml
+++ b/keycard-ui/qml/DebugPanel.qml
@@ -1019,15 +1019,22 @@ Rectangle {
                                     var parsed = JSON.parse(result)
 
                                     if (parsed.status === "complete") {
-                                        // Success — now retrieve key via the one-read-and-drop path
+                                        // Success — retrieve key via the one-read-and-drop path
                                         var keyResult = logos.callModule("keycard", "checkAuthStatus",
                                             [authWindow.currentAuthId])
                                         var keyParsed = JSON.parse(keyResult)
-                                        var derivedKey = (keyParsed.key) ? keyParsed.key : ""
-                                        refreshPendingAuths()
-                                        authWindow.currentAuthId = ""
-                                        authWindow.authorizationComplete(true, derivedKey)
-                                        authWindow.close()
+
+                                        if (keyParsed.key) {
+                                            refreshPendingAuths()
+                                            authWindow.currentAuthId = ""
+                                            authWindow.authorizationComplete(true, keyParsed.key)
+                                            authWindow.close()
+                                        } else {
+                                            // Key fetch failed — keep dialog open, show error
+                                            errorText.text = keyParsed.error || "Failed to retrieve derived key"
+                                            pinField.clear()
+                                            pinField.forceActiveFocus()
+                                        }
                                     } else if (parsed.status === "failed") {
                                         errorText.text = parsed.error || "Authorization failed"
 

--- a/keycard-ui/qml/DebugPanel.qml
+++ b/keycard-ui/qml/DebugPanel.qml
@@ -1019,10 +1019,14 @@ Rectangle {
                                     var parsed = JSON.parse(result)
 
                                     if (parsed.status === "complete") {
-                                        // Success - legitimate key from hardware
+                                        // Success — now retrieve key via the one-read-and-drop path
+                                        var keyResult = logos.callModule("keycard", "checkAuthStatus",
+                                            [authWindow.currentAuthId])
+                                        var keyParsed = JSON.parse(keyResult)
+                                        var derivedKey = (keyParsed.key) ? keyParsed.key : ""
                                         refreshPendingAuths()
                                         authWindow.currentAuthId = ""
-                                        authWindow.authorizationComplete(true, parsed.key)
+                                        authWindow.authorizationComplete(true, derivedKey)
                                         authWindow.close()
                                     } else if (parsed.status === "failed") {
                                         errorText.text = parsed.error || "Authorization failed"


### PR DESCRIPTION
## Summary

- Port `SecureBuffer` RAII class from logos-notes (`sodium_memzero` on destroy)
- `AuthRequest.key` stored as `SecureBuffer` instead of `QString`
- `checkAuthStatus()` returns key exactly once, then wipes and removes the request
- `closeSession()`, card-gone detection, and destructor all purge completed requests

Fixes #94

## Test plan

- [ ] Build passes (verified)
- [ ] Verify with physical card: full auth flow returns key once
- [ ] Verify second `checkAuthStatus()` with same `authId` returns "Auth request not found"
- [ ] Verify `closeSession()` wipes any unread completed requests
- [ ] Verify card removal triggers purge
- [ ] Senty review

🤖 Generated with [Claude Code](https://claude.com/claude-code)