### PR TITLE
fix(#125): pending requests gate — defer checkPairing, add checkPairingBusy guard

### DIFF
--- a/keycard-ui/qml/PinEntryScreen.qml
+++ b/keycard-ui/qml/PinEntryScreen.qml
@@ -24,6 +24,7 @@ FocusScope {
     property bool verifyingPin: false
     property int attemptsRemaining: 3
     property bool checkHardwareBusy: false
+    property bool checkPairingBusy: false
 
     // logos.callModule wraps the C++ QString return in an extra JSON layer — parse twice
     function callModuleParse(raw) {
@@ -79,7 +80,7 @@ FocusScope {
                 if (wasCard !== root.cardDetected) {
                     if (root.cardDetected) {
                         activityLog.addEntry(ts, "Keycard detected", "success")
-                        checkPairing()
+                        Qt.callLater(root.checkPairing)
                     } else {
                         activityLog.addEntry(ts, "Keycard not detected", "error")
                         root.paired = false
@@ -87,6 +88,7 @@ FocusScope {
                         root.pairingStatus = ""
                         root.currentRequest = null
                         root.pendingChecked = false
+                        root.checkPairingBusy = false
                     }
                 }
             } catch (e) {}
@@ -98,17 +100,21 @@ FocusScope {
                 root.pairingStatus = ""
                 root.currentRequest = null
                 root.pendingChecked = false
+                root.checkPairingBusy = false
                 activityLog.addEntry(ts, "Keycard not detected", "error")
             }
         }
 
-        if (root.paired && !root.currentRequest) {
+        if (root.cardDetected && !root.currentRequest) {
             checkPendingRequests()
         }
         root.checkHardwareBusy = false
     }
 
     function checkPairing() {
+        if (root.checkPairingBusy) return
+        root.checkPairingBusy = true
+
         var ts = Qt.formatTime(new Date(), "[HH:mm:ss]")
         activityLog.addEntry(ts, "Checking pairing...", "info")
 
@@ -130,6 +136,7 @@ FocusScope {
                 activityLog.addEntry(ts, "Keycard not paired", "warning")
             }
         } catch (e) {}
+        root.checkPairingBusy = false
     }
 
     function checkPendingRequests() {

--- a/keycard-ui/qml/PinEntryScreen.qml
+++ b/keycard-ui/qml/PinEntryScreen.qml
@@ -18,6 +18,10 @@ FocusScope {
         if (currentRequest !== null && paired)
             hiddenInput.forceActiveFocus()
     }
+    onPairedChanged: {
+        if (paired && currentRequest !== null)
+            hiddenInput.forceActiveFocus()
+    }
     property bool pendingChecked: false
     property string pinValue: ""
     property int maxPinLength: 6


### PR DESCRIPTION
## Summary

- `checkPairing()` was called synchronously in `checkHardware()`, blocking for ~40s across 3 `callModule` calls — `checkPendingRequests()` only ran after the full block
- `checkPendingRequests()` was also gated on `root.paired`, so unpaired cards never surfaced pending requests at all

## Changes

- `Qt.callLater(root.checkPairing)` — defers pairing so `checkHardware()` returns immediately; `checkPendingRequests()` now runs in the same cycle as card detection
- `checkPairingBusy` guard — prevents re-entrant pairing calls from subsequent hwTimer fires during the blocking window
- Gate fix: `root.cardDetected` instead of `root.paired` for `checkPendingRequests()` — requests now surface on unpaired cards too
- Reset `checkPairingBusy` in both card-removed paths

## Verified

- Card insert → "Keycard detected" + "Checking pairing..." + request from `auth_showcase` all appear within ~2s
- No 40s delay before pending request surfaces

🤖 Generated with [Claude Code](https://claude.com/claude-code)