### PR TITLE
docs: CTA buttons + integration guide polish (#137, #138)

### DIFF
--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -24,8 +24,6 @@ Add hardware-backed signing or key derivation to your Basecamp module.
 
 ## Signing (primary use case)
 
-> **Not on master yet.** `requestSign`/`checkSignStatus` are implemented on branch [`issue-98-request-sign`](https://github.com/xAlisher/keycard-basecamp/tree/issue-98-request-sign), pending merge. If you're integrating today against the current release, use [Key derivation](#key-derivation-for-encryption) instead. This section documents the API as it will ship.
-
 Use signing when your module needs to commit to data — messages, transactions, votes — without managing keys. The private key never leaves the smartcard.
 
 The flow: call `requestSign` with your payload hash, domain, caller, and scheme → poll `checkSignStatus` until the user approves in keycard-ui → receive the signature once.

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -26,13 +26,19 @@ Add hardware-backed signing or key derivation to your Basecamp module in 5 minut
 
 Use signing when your module needs to commit to data — messages, transactions, votes — without managing keys. The private key never leaves the smartcard.
 
+There is no `KeycardSign.qml` drop-in component — signing uses the manual flow below.
+
 ```qml
 property string signId: ""
 
 // Step 1: Request a signature
 function requestSignature(payloadHash) {
-    var result = logos.callModule("keycard", "requestSign",
-                                  ["my_module_signing", payloadHash, "ecdsa"])
+    var result = logos.callModule("keycard", "requestSign", [JSON.stringify({
+        domain: "my_module_signing",
+        payloadHash: payloadHash,
+        caller: "my_module",
+        scheme: "ecdsa"
+    })])
     var response = JSON.parse(result)
     if (response.signId) {
         signId = response.signId
@@ -61,11 +67,12 @@ Timer {
 }
 ```
 
-**Parameters for `requestSign`:**
-| Name | Type | Description |
-|------|------|-------------|
+**`requestSign` JSON fields:**
+| Field | Type | Description |
+|-------|------|-------------|
 | `domain` | string | Determines the BIP32 derivation path — same domain, same signing key |
-| `hash` | string | Hex-encoded hash of your payload — the card signs this directly |
+| `payloadHash` | string | Hex-encoded hash of your payload — the card signs this directly |
+| `caller` | string | Your module name — shown to the user in the approval panel |
 | `scheme` | string | `"ecdsa"` or `"schnorr"` (BIP340) |
 
 **`checkSignStatus` response when complete:**

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Keycard Integration Guide
 
-Add hardware-backed signing or key derivation to your Basecamp module in 5 minutes.
+Add hardware-backed signing or key derivation to your Basecamp module.
 
 ---
 
@@ -26,54 +26,26 @@ Add hardware-backed signing or key derivation to your Basecamp module in 5 minut
 
 Use signing when your module needs to commit to data — messages, transactions, votes — without managing keys. The private key never leaves the smartcard.
 
-There is no `KeycardSign.qml` drop-in component — signing uses the manual flow below.
+The flow: call `requestSign` with your payload hash, domain, caller, and scheme → poll `checkSignStatus` until the user approves in keycard-ui → receive the signature once.
 
-```qml
-property string signId: ""
+No drop-in component yet — signing uses the manual flow. Signing showcase coming with [#98](https://github.com/xAlisher/keycard-basecamp/issues/98).
 
-// Step 1: Request a signature
-function requestSignature(payloadHash) {
-    var result = logos.callModule("keycard", "requestSign", [JSON.stringify({
-        domain: "my_module_signing",
-        payloadHash: payloadHash,
-        caller: "my_module",
-        scheme: "ecdsa"
-    })])
-    var response = JSON.parse(result)
-    if (response.signId) {
-        signId = response.signId
-        signPoller.start()
-    }
-}
-
-// Step 2: Poll for result (1 second interval)
-Timer {
-    id: signPoller
-    interval: 1000
-    repeat: true
-    onTriggered: {
-        var result = logos.callModule("keycard", "checkSignStatus", [signId])
-        var r = JSON.parse(result)
-
-        if (r.status === "complete" && r.signature) {
-            signPoller.stop()
-            useSignature(r.signature)   // r.scheme: "ecdsa" or "schnorr"
-        } else if (r.status === "rejected" || r.error) {
-            signPoller.stop()
-            showError(r.error || "Signing rejected")
-        }
-        // "pending" → keep polling
-    }
-}
-```
-
-**`requestSign` JSON fields:**
+**`requestSign` takes a single JSON string argument:**
 | Field | Type | Description |
 |-------|------|-------------|
 | `domain` | string | Determines the BIP32 derivation path — same domain, same signing key |
 | `payloadHash` | string | Hex-encoded hash of your payload — the card signs this directly |
 | `caller` | string | Your module name — shown to the user in the approval panel |
 | `scheme` | string | `"ecdsa"` or `"schnorr"` (BIP340) |
+
+```javascript
+logos.callModule("keycard", "requestSign", [JSON.stringify({
+    domain: "my_module_signing",
+    payloadHash: hash,
+    caller: "my_module",
+    scheme: "ecdsa"
+})])
+```
 
 **`checkSignStatus` response when complete:**
 ```json
@@ -85,86 +57,55 @@ Timer {
 }
 ```
 
-**Path note:** signing uses a non-EIP-1581 BIP32 path. This is intentional — it means the signing key can never be exported from the card, even by the keycard module itself. Keys that sign and keys that encrypt are derived at separate paths and cannot be confused.
+**Path note:** signing uses a non-EIP-1581 BIP32 path. This means the signing key can never be exported from the card — even by the keycard module itself. Keys that sign and keys that encrypt are derived at separate paths and cannot be confused.
 
 ---
 
-## Private key generation (for encryption)
+## Key derivation (for encryption)
 
-Use key derivation when your module needs to encrypt local data and needs a stable key it can reproduce later. The key is derived on-card, returned to your module once, and must be wiped from memory when done.
+Use key derivation when your module needs to encrypt local data and needs a stable key it can reproduce later. The key is derived on-card, returned once, and must be wiped from memory when done.
+
+The flow: call `requestAuth` with a domain and caller → poll `checkAuthStatus` → receive the derived key once → wipe it after use.
+
+**See it in action:** [`auth_showcase-ui/qml/Main.qml`](auth_showcase-ui/qml/Main.qml) is a complete, running integration. The three functions to read:
+- [`requestAuth()`](auth_showcase-ui/qml/Main.qml#L50) — queues the request
+- [`checkAuthStatus()`](auth_showcase-ui/qml/Main.qml#L79) — polls for the result
+- [`callModuleParse()`](auth_showcase-ui/qml/Main.qml#L30) — handles the double-JSON-wrap quirk ([#121](https://github.com/xAlisher/keycard-basecamp/issues/121))
 
 ### Drop-in component
 
-Copy `KeycardAuth.qml` from keycard-basecamp into your module's QML directory, then:
+For the common case, copy `KeycardAuth.qml` from keycard-basecamp into your module's QML directory:
 
 ```qml
-import QtQuick 2.15
+KeycardAuth {
+    domain: "my_module_encryption"   // Unique domain for your key
+    caller: "my_module"              // Your module name
 
-Item {
-    // Your module UI...
-
-    KeycardAuth {
-        id: keycardAuth
-        anchors.centerIn: parent
-        width: 320
-
-        domain: "my_module_encryption"   // Unique domain for your key
-        caller: "my_module"              // Your module name
-
-        onKeyReceived: function(hexKey) {
-            // hexKey is a 64-char hex string (32 bytes)
-            // Use it for encryption, then wipe — do not store it
-            myBackend.useKey(hexKey)
-            // Backend must wipe the key from memory after use
-        }
-
-        onError: function(message) {
-            errorText.text = message
-        }
+    onKeyReceived: function(hexKey) {
+        myBackend.useKey(hexKey)     // Wipe after use — do not store
     }
+    onError: function(message) { errorText.text = message }
 }
 ```
 
-The component handles the "Connect with Keycard" button, polling, status display, error handling, and auto-reset after key delivery.
+The component handles the button, polling, status display, error handling, and auto-reset.
 
-### Manual integration
+**`requestAuth` parameters:**
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `domain` | string | Key derivation domain — same domain always produces the same key |
+| `caller` | string | Your module name — shown to the user in the approval panel |
 
-```qml
-property string authId: ""
-
-// Step 1: Request key derivation
-function requestKey() {
-    var result = logos.callModule("keycard", "requestAuth",
-                                  ["my_domain_encryption", "my_module"])
-    var response = JSON.parse(result)
-    if (response.authId) {
-        authId = response.authId
-        pollTimer.start()
-    }
-}
-
-// Step 2: Poll for result (1 second interval)
-Timer {
-    id: pollTimer
-    interval: 1000
-    repeat: true
-    onTriggered: {
-        var result = logos.callModule("keycard", "checkAuthStatus", [authId])
-        var r = JSON.parse(result)
-
-        if (r.status === "complete" && r.key) {
-            pollTimer.stop()
-            useKey(r.key)   // 64-char hex, 32 bytes — wipe after use
-        } else if (r.status === "rejected" || r.error) {
-            pollTimer.stop()
-            showError(r.error || "Authorization rejected")
-        }
-        // "pending" → keep polling (wrong PINs stay pending so the user can retry)
-    }
+**`checkAuthStatus` response when complete:**
+```json
+{
+  "authId": "...",
+  "status": "complete",
+  "key": "a1b2c3..."
 }
 ```
 
-**Path note:** `requestAuth` derives keys at EIP-1581 BIP32 paths — the only paths the Keycard applet allows for key export. This is enforced on-card. The key exists in host memory for a single read, then the request is wiped. Your module is responsible for wiping it from application memory after use.
+**Path note:** `requestAuth` derives keys at EIP-1581 BIP32 paths — the only paths the Keycard applet allows for export. This is enforced on-card. The key exists in host memory for a single read, then the request is wiped. Your module is responsible for wiping it from application memory after use.
 
 ---
 
@@ -177,7 +118,7 @@ When your module calls `requestSign` or `requestAuth`, a pending request appears
 3. Taps the card to the reader and enters their PIN
 4. Approves or declines
 
-On approval, your poller receives `status: "complete"` with the signature or key. On decline, it receives `status: "rejected"`. The session closes automatically after each approval — one approval, one result.
+On approval, your poller receives `status: "complete"` with the signature or key. On decline, it receives `status: "rejected"`. The session closes automatically — one approval, one result.
 
 ---
 
@@ -192,7 +133,7 @@ Examples:
 - `"wallet_signing"` — transaction signing
 - `"governance_vote"` — voting commitments
 
-**The domain is the identity of the key.** Use a stable, unique string — changing it produces a different key. The domain maps deterministically to a BIP32 path. Same domain + same card = same key, always. Different domains produce isolated keyspaces with no relation to each other.
+**The domain is the identity of the key.** Use a stable, unique string — changing it produces a different key. Same domain + same card = same key, always. Different domains produce isolated keyspaces with no relation to each other.
 
 ---
 
@@ -200,12 +141,12 @@ Examples:
 
 | Pitfall | Fix |
 |---------|-----|
-| `callModule` returns a string | Always `JSON.parse()` before accessing fields |
-| Poller loops forever | Handle all response types: `complete`, `rejected`, AND `{error: ...}` for expired IDs. There is no `failed` status — wrong PINs stay `pending` so the user can retry |
+| `callModule` returns a string | Always `JSON.parse()` — or use `callModuleParse()` from the showcase to handle the double-wrap quirk ([#121](https://github.com/xAlisher/keycard-basecamp/issues/121)) |
+| Poller loops forever | Handle all terminal states: `complete`, `rejected`, AND `{error: ...}` for expired IDs. There is no `failed` status — wrong PINs stay `pending` so the user can retry |
 | Key "changes" between sessions | It doesn't — same domain = same key. Session auto-closes, so each operation needs a new request |
 | "Auth request not found" | The ID expired or was already consumed. Start a new request |
-| Component doesn't render | `KeycardAuth.qml` must be in the same directory as your `Main.qml` |
-| Storing the derived key | Don't. Wipe it after use. Request again next time — same domain reproduces it |
+| `KeycardAuth.qml` doesn't render | Must be in the same directory as your `Main.qml` |
+| Storing the derived key | Don't. Wipe after use. Request again next time — same domain reproduces it |
 
 ---
 

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -24,6 +24,8 @@ Add hardware-backed signing or key derivation to your Basecamp module.
 
 ## Signing (primary use case)
 
+> **Not on master yet.** `requestSign`/`checkSignStatus` are implemented on branch [`issue-98-request-sign`](https://github.com/xAlisher/keycard-basecamp/tree/issue-98-request-sign), pending merge. If you're integrating today against the current release, use [Key derivation](#key-derivation-for-encryption) instead. This section documents the API as it will ship.
+
 Use signing when your module needs to commit to data — messages, transactions, votes — without managing keys. The private key never leaves the smartcard.
 
 The flow: call `requestSign` with your payload hash, domain, caller, and scheme → poll `checkSignStatus` until the user approves in keycard-ui → receive the signature once.

--- a/INTEGRATION_GUIDE.md
+++ b/INTEGRATION_GUIDE.md
@@ -1,6 +1,6 @@
 # Keycard Integration Guide
 
-Add hardware key derivation to your Basecamp module in 5 minutes.
+Add hardware-backed signing or key derivation to your Basecamp module in 5 minutes.
 
 ---
 
@@ -14,11 +14,79 @@ Add hardware key derivation to your Basecamp module in 5 minutes.
 }
 ```
 
-2. **Keycard module installed** in Basecamp (keycard-core + keycard-ui)
+2. **Install Keycard LGX packages** in Basecamp:
+   - `keycard-core.lgx` — C++ backend, PC/SC integration
+   - `keycard-ui.lgx` — Approval panel for PIN entry
+
+   Download from [keycard-basecamp releases](https://github.com/xAlisher/keycard-basecamp/releases) and install both via Basecamp's module manager.
 
 ---
 
-## Quick Start: Drop-in Component
+## Signing (primary use case)
+
+Use signing when your module needs to commit to data — messages, transactions, votes — without managing keys. The private key never leaves the smartcard.
+
+```qml
+property string signId: ""
+
+// Step 1: Request a signature
+function requestSignature(payloadHash) {
+    var result = logos.callModule("keycard", "requestSign",
+                                  ["my_module_signing", payloadHash, "ecdsa"])
+    var response = JSON.parse(result)
+    if (response.signId) {
+        signId = response.signId
+        signPoller.start()
+    }
+}
+
+// Step 2: Poll for result (1 second interval)
+Timer {
+    id: signPoller
+    interval: 1000
+    repeat: true
+    onTriggered: {
+        var result = logos.callModule("keycard", "checkSignStatus", [signId])
+        var r = JSON.parse(result)
+
+        if (r.status === "complete" && r.signature) {
+            signPoller.stop()
+            useSignature(r.signature)   // r.scheme: "ecdsa" or "schnorr"
+        } else if (r.status === "rejected" || r.error) {
+            signPoller.stop()
+            showError(r.error || "Signing rejected")
+        }
+        // "pending" → keep polling
+    }
+}
+```
+
+**Parameters for `requestSign`:**
+| Name | Type | Description |
+|------|------|-------------|
+| `domain` | string | Determines the BIP32 derivation path — same domain, same signing key |
+| `hash` | string | Hex-encoded hash of your payload — the card signs this directly |
+| `scheme` | string | `"ecdsa"` or `"schnorr"` (BIP340) |
+
+**`checkSignStatus` response when complete:**
+```json
+{
+  "signId": "...",
+  "status": "complete",
+  "signature": "a1b2c3...",
+  "scheme": "ecdsa"
+}
+```
+
+**Path note:** signing uses a non-EIP-1581 BIP32 path. This is intentional — it means the signing key can never be exported from the card, even by the keycard module itself. Keys that sign and keys that encrypt are derived at separate paths and cannot be confused.
+
+---
+
+## Private key generation (for encryption)
+
+Use key derivation when your module needs to encrypt local data and needs a stable key it can reproduce later. The key is derived on-card, returned to your module once, and must be wiped from memory when done.
+
+### Drop-in component
 
 Copy `KeycardAuth.qml` from keycard-basecamp into your module's QML directory, then:
 
@@ -38,9 +106,9 @@ Item {
 
         onKeyReceived: function(hexKey) {
             // hexKey is a 64-char hex string (32 bytes)
-            // Use it for AES-256-GCM or whatever your module needs
-            console.log("Got key:", hexKey.substring(0, 16) + "...")
+            // Use it for encryption, then wipe — do not store it
             myBackend.useKey(hexKey)
+            // Backend must wipe the key from memory after use
         }
 
         onError: function(message) {
@@ -50,26 +118,17 @@ Item {
 }
 ```
 
-That's it. The component handles:
-- "Connect with Keycard" button
-- Polling for approval
-- "Switch to Keycard module to approve" status
-- Error handling and retry
-- Auto-reset after key delivery
+The component handles the "Connect with Keycard" button, polling, status display, error handling, and auto-reset after key delivery.
 
----
-
-## Quick Start: Manual Integration
-
-If you need more control, call the keycard module directly:
+### Manual integration
 
 ```qml
 property string authId: ""
 
-// Step 1: Request auth
+// Step 1: Request key derivation
 function requestKey() {
     var result = logos.callModule("keycard", "requestAuth",
-                                  ["my_domain", "my_module"])
+                                  ["my_domain_encryption", "my_module"])
     var response = JSON.parse(result)
     if (response.authId) {
         authId = response.authId
@@ -88,85 +147,62 @@ Timer {
 
         if (r.status === "complete" && r.key) {
             pollTimer.stop()
-            useKey(r.key)
+            useKey(r.key)   // 64-char hex, 32 bytes — wipe after use
         } else if (r.status === "rejected" || r.error) {
             pollTimer.stop()
             showError(r.error || "Authorization rejected")
         }
-        // "pending" → keep polling (wrong PINs are retried in the approval panel and stay pending)
+        // "pending" → keep polling (wrong PINs stay pending so the user can retry)
     }
 }
 ```
 
----
-
-## How It Works
-
-```
-┌──────────────┐     requestAuth      ┌──────────────┐
-│  Your Module  │ ──────────────────→  │   Keycard     │
-│              │                       │   Module      │
-│  polls with  │     checkAuthStatus   │              │
-│  authId      │ ←──────────────────   │  queues      │
-│              │     status: pending   │  request     │
-└──────────────┘                       └──────┬───────┘
-                                              │
-                                    ┌─────────▼────────┐
-                                    │   Keycard UI     │
-                                    │                  │
-                                    │  Shows request   │
-                                    │  User enters PIN │
-                                    │  Approves        │
-                                    └──────────────────┘
-                                              │
-┌──────────────┐     checkAuthStatus          │
-│  Your Module  │ ←───────────────────────────┘
-│              │     status: complete
-│  receives    │     key: "a1b2c3..."
-│  derived key │
-└──────────────┘
-```
+**Path note:** `requestAuth` derives keys at EIP-1581 BIP32 paths — the only paths the Keycard applet allows for key export. This is enforced on-card. The key exists in host memory for a single read, then the request is wiped. Your module is responsible for wiping it from application memory after use.
 
 ---
 
-## Key Properties
+## What the user sees
 
-- **Deterministic**: Same domain + same card = same key, every time
-- **Domain-isolated**: Different domains produce different keys
-- **Hardware-bound**: Key never leaves the smartcard chip
-- **Session-scoped**: Session auto-closes after each approval — request again for next operation
-- **No PIN exposure**: Your module never sees the PIN — keycard-ui handles it
+When your module calls `requestSign` or `requestAuth`, a pending request appears in keycard-ui. The user:
+
+1. Switches to the Keycard module (or keycard-ui surfaces it automatically)
+2. Sees the request — domain name and your module as caller
+3. Taps the card to the reader and enters their PIN
+4. Approves or declines
+
+On approval, your poller receives `status: "complete"` with the signature or key. On decline, it receives `status: "rejected"`. The session closes automatically after each approval — one approval, one result.
 
 ---
 
-## Domain Naming Convention
+## Domain naming
 
 ```
 "modulename_purpose"
 ```
 
 Examples:
-- `"notes_encryption"` — for encrypting notes
-- `"wallet_signing"` — for transaction signing
-- `"storage_vault"` — for encrypted file storage
+- `"notes_encryption"` — encrypting notes content
+- `"wallet_signing"` — transaction signing
+- `"governance_vote"` — voting commitments
 
-The domain maps deterministically to a BIP32 derivation path via EIP-1581. Same domain always produces the same key from the same card.
+**The domain is the identity of the key.** Use a stable, unique string — changing it produces a different key. The domain maps deterministically to a BIP32 path. Same domain + same card = same key, always. Different domains produce isolated keyspaces with no relation to each other.
 
 ---
 
-## Common Pitfalls
+## Common pitfalls
 
 | Pitfall | Fix |
 |---------|-----|
 | `callModule` returns a string | Always `JSON.parse()` before accessing fields |
-| Poller loops forever | Handle ALL response types: complete, rejected, AND `{error: ...}` shape for expired authIds. Do not wait for `failed` — it is not emitted by the consumer API; wrong PINs stay `pending` so the user can retry |
-| Key "changes" between sessions | It doesn't — same domain = same key. But session auto-closes, so you need a new `requestAuth` each time |
-| "Auth request not found" | The authId expired or was already consumed. Start a new `requestAuth` |
-| Component doesn't render | Make sure `KeycardAuth.qml` is in the same directory as your Main.qml |
+| Poller loops forever | Handle all response types: `complete`, `rejected`, AND `{error: ...}` for expired IDs. There is no `failed` status — wrong PINs stay `pending` so the user can retry |
+| Key "changes" between sessions | It doesn't — same domain = same key. Session auto-closes, so each operation needs a new request |
+| "Auth request not found" | The ID expired or was already consumed. Start a new request |
+| Component doesn't render | `KeycardAuth.qml` must be in the same directory as your `Main.qml` |
+| Storing the derived key | Don't. Wipe it after use. Request again next time — same domain reproduces it |
 
 ---
 
-## Filing Bugs
+## Filing bugs
 
 Found a problem with the keycard API? **File an issue on [keycard-basecamp](https://github.com/xAlisher/keycard-basecamp)**, not on your module's repo.
 
@@ -177,6 +213,6 @@ Include:
 
 ---
 
-## Full API Reference
+## Full API reference
 
 See [KEYCARD_API.md](KEYCARD_API.md) for the complete method reference with every response shape documented.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@ Think of it like a password manager — but there's no vault, no master password
 
 > **Experimental — not for production use.** This project builds against a pre-release, unstable version of Logos Basecamp. APIs will break, behavior will change without notice. If you're looking for a consumer-facing key management solution, this isn't it yet.
 
+| [Try the showcase →](docs/INSTALL.md) | [Integration guide →](INTEGRATION_GUIDE.md) |
+|---|---|
+
 **Status:** 🚧 Active development — [v1.0.0 LGX packages available](https://github.com/xAlisher/keycard-basecamp/releases/tag/v1.0.0) (dev use only)
 
 ## How It Works

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,37 @@
+# Try the Keycard Showcase
+
+The quickest way to see Keycard working in Basecamp is to install the pre-built LGX packages and run the included showcase module.
+
+## Requirements
+
+- [Logos Basecamp](https://github.com/logos-co/logos-basecamp) (pre-release)
+- PC/SC smart card reader
+- [Keycard](https://keycard.tech/) smartcard (initialized and paired)
+
+## Install
+
+1. **Download the latest release** from [keycard-basecamp releases](https://github.com/xAlisher/keycard-basecamp/releases/latest):
+   - `keycard-core.lgx`
+   - `keycard-ui.lgx`
+   - `auth_showcase.lgx`
+
+2. **Install all three LGX files** via Basecamp's module manager (Settings → Modules → Install from file).
+
+3. **Restart Basecamp.** All three modules should appear in the module list.
+
+## Run
+
+1. Open the **Keycard** module — it will detect your reader and card.
+2. Pair your card if not already paired (Pair tab → enter pairing password + PIN).
+3. Open the **Auth Showcase** module.
+4. Click **Request Auth** — a pending request will appear in the Keycard module.
+5. Switch back to Keycard, enter your PIN, and approve.
+6. The showcase module receives the derived key and displays confirmation.
+
+## Build from source
+
+See the [README](../README.md#build) for build instructions.
+
+## Next step
+
+Ready to integrate Keycard into your own module? See the [Integration Guide](../INTEGRATION_GUIDE.md).

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,6 +1,6 @@
-# Try the Keycard Showcase
+# Try Keycard in Basecamp
 
-The quickest way to see Keycard working in Basecamp is to install the pre-built LGX packages and run the included showcase module.
+The quickest way to get Keycard running in Basecamp is to install the two pre-built LGX packages. Once installed, you can exercise the full approval flow from any module.
 
 ## Requirements
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -13,24 +13,26 @@ The quickest way to see Keycard working in Basecamp is to install the pre-built 
 1. **Download the latest release** from [keycard-basecamp releases](https://github.com/xAlisher/keycard-basecamp/releases/latest):
    - `keycard-core.lgx`
    - `keycard-ui.lgx`
-   - `auth_showcase.lgx`
 
-2. **Install all three LGX files** via Basecamp's module manager (Settings → Modules → Install from file).
+2. **Install both LGX files** via Basecamp's module manager (Settings → Modules → Install from file).
 
-3. **Restart Basecamp.** All three modules should appear in the module list.
+3. **Restart Basecamp.** Both modules should appear in the module list.
 
-## Run
+## Try it
+
+With both modules installed you can exercise the full approval flow:
 
 1. Open the **Keycard** module — it will detect your reader and card.
 2. Pair your card if not already paired (Pair tab → enter pairing password + PIN).
-3. Open the **Auth Showcase** module.
-4. Click **Request Auth** — a pending request will appear in the Keycard module.
-5. Switch back to Keycard, enter your PIN, and approve.
-6. The showcase module receives the derived key and displays confirmation.
+3. From any module's QML, call `logos.callModule("keycard", "requestAuth", ["test_domain", "my_module"])` and poll `checkAuthStatus` — or drop in `KeycardAuth.qml` (see the [Integration Guide](../INTEGRATION_GUIDE.md#private-key-generation-for-encryption)).
+4. The pending request will appear in the Keycard UI. Enter your PIN and approve.
+5. The derived key is returned to the calling module.
 
-## Build from source
+## Build the showcase from source
 
-See the [README](../README.md#build) for build instructions.
+`auth_showcase` is not included in the current release. To run the full showcase demo, build from source:
+
+See the [README](../README.md#build) for build instructions, then install `auth_showcase` alongside `keycard-core` and `keycard-ui`.
 
 ## Next step
 

--- a/docs/blog/keycard-logos-ecosystem-post.md
+++ b/docs/blog/keycard-logos-ecosystem-post.md
@@ -65,3 +65,8 @@ The greatest expeditions start at Basecamp.
 If you want something that doesn't exist yet, you don't wait.
 
 **[Build it → build.logos.co](https://build.logos.co)**
+
+---
+
+| [Try the showcase →](https://github.com/xAlisher/keycard-basecamp/blob/master/docs/INSTALL.md) | [Integration guide →](https://github.com/xAlisher/keycard-basecamp/blob/master/INTEGRATION_GUIDE.md) |
+|---|---|


### PR DESCRIPTION
## Summary

- **README + ecosystem post**: two-button CTA (`Try the showcase` / `Integration guide`) after the experimental disclaimer
- **docs/INSTALL.md**: new quick-start for installing Keycard in Basecamp (CTA link target)
- **INTEGRATION_GUIDE.md**: restructured with signing as primary use case (`requestSign`/`checkSignStatus`, JSON arg shape, scheme param, non-EIP-1581 path note), key derivation as secondary (`requestAuth`/`checkAuthStatus`, EIP-1581 note, wipe-after-use), domain naming expanded

## Merge hold

⚠️ **Do not merge until signing branches (#98) land on master.** The guide's signing section documents `requestSign`/`checkSignStatus` which isn't on master yet. After signing merges: rebase this branch, verify snippets still match, then merge.

## Review

Senty reviewed two rounds — all findings resolved. LGTM on both #137 and #138.

🤖 Generated with [Claude Code](https://claude.com/claude-code)