### PR TITLE
fix(#149,#150): arbitrary BIP32 paths + separate signing subtree (1582')

### DIFF
--- a/keycard-core/src/plugin.cpp
+++ b/keycard-core/src/plugin.cpp
@@ -279,6 +279,27 @@ QString KeycardPlugin::domainToPath(const QString& domain)
     return QString("m/43'/60'/1581'/%1'/%2'/%3'/%4'").arg(idx1).arg(idx2).arg(idx3).arg(idx4);
 }
 
+// domainToSignPath — same hash → indices as domainToPath, but rooted at m/43'/60'/1582'.
+// 1582' is a non-exportable subtree: chain code export is not permitted there, so signing
+// keys derived here cannot be exfiltrated via the EXPORT_KEY APDU. (#150)
+QString KeycardPlugin::domainToSignPath(const QString& domain)
+{
+    QByteArray namespaced = ("logos-" + domain).toUtf8();
+    unsigned char hash[32];
+    crypto_hash_sha256(hash, reinterpret_cast<const unsigned char*>(namespaced.constData()), namespaced.size());
+
+    uint32_t idx1 = (uint32_t(hash[0])  << 24 | uint32_t(hash[1])  << 16 |
+                     uint32_t(hash[2])  << 8  | uint32_t(hash[3]))  & 0x7FFFFFFF;
+    uint32_t idx2 = (uint32_t(hash[4])  << 24 | uint32_t(hash[5])  << 16 |
+                     uint32_t(hash[6])  << 8  | uint32_t(hash[7]))  & 0x7FFFFFFF;
+    uint32_t idx3 = (uint32_t(hash[8])  << 24 | uint32_t(hash[9])  << 16 |
+                     uint32_t(hash[10]) << 8  | uint32_t(hash[11])) & 0x7FFFFFFF;
+    uint32_t idx4 = (uint32_t(hash[12]) << 24 | uint32_t(hash[13]) << 16 |
+                     uint32_t(hash[14]) << 8  | uint32_t(hash[15])) & 0x7FFFFFFF;
+
+    return QString("m/43'/60'/1582'/%1'/%2'/%3'/%4'").arg(idx1).arg(idx2).arg(idx3).arg(idx4);
+}
+
 QString KeycardPlugin::deriveKey(const QString& domain)
 {
     qDebug() << "KeycardPlugin::deriveKey() called, domain:" << domain;
@@ -943,10 +964,17 @@ QString KeycardPlugin::requestSign(const QString& jsonArgs)
     QString payloadHash = args.value("payloadHash").toString();
     QString caller      = args.value("caller").toString();
     QString scheme      = args.value("scheme").toString().toLower();
+    QString bip32_path  = args.value("bip32_path").toString();  // optional (#149)
 
-    if (domain.isEmpty() || payloadHash.isEmpty() || caller.isEmpty()) {
+    // Either domain or bip32_path must be present (bip32_path takes precedence)
+    if (bip32_path.isEmpty() && domain.isEmpty()) {
         QJsonObject err;
-        err["error"] = "Missing required fields: domain, payloadHash, caller";
+        err["error"] = "Provide either domain or bip32_path";
+        return QJsonDocument(err).toJson(QJsonDocument::Compact);
+    }
+    if (payloadHash.isEmpty() || caller.isEmpty()) {
+        QJsonObject err;
+        err["error"] = "Missing required fields: payloadHash, caller";
         return QJsonDocument(err).toJson(QJsonDocument::Compact);
     }
     if (scheme != "ecdsa" && scheme != "schnorr") {
@@ -957,6 +985,11 @@ QString KeycardPlugin::requestSign(const QString& jsonArgs)
     if (QByteArray::fromHex(payloadHash.toUtf8()).size() != 32) {
         QJsonObject err;
         err["error"] = "payloadHash must be hex-encoded 32 bytes";
+        return QJsonDocument(err).toJson(QJsonDocument::Compact);
+    }
+    if (!bip32_path.isEmpty() && !bip32_path.startsWith("m/")) {
+        QJsonObject err;
+        err["error"] = "bip32_path must start with \"m/\"";
         return QJsonDocument(err).toJson(QJsonDocument::Compact);
     }
 
@@ -972,6 +1005,7 @@ QString KeycardPlugin::requestSign(const QString& jsonArgs)
     req.payloadHash = payloadHash;
     req.caller      = caller;
     req.scheme      = scheme;
+    req.bip32_path  = bip32_path;
     req.status      = "pending";
     req.timestamp   = QDateTime::currentMSecsSinceEpoch();
     m_signRequests.push_back(std::move(req));
@@ -1040,12 +1074,17 @@ QString KeycardPlugin::getPendingSigns()
         obj["scheme"]      = req.scheme;
         obj["payloadHash"] = req.payloadHash;
         obj["timestamp"]   = req.timestamp;
+        if (!req.bip32_path.isEmpty())
+            obj["bip32_path"] = req.bip32_path;
         pending.append(obj);
 
         if (!m_loggedRequestIds.contains(req.id)) {
             QString shortId = req.id.left(8);
-            logActivity(QString("[%1] New %2 sign request from %3 for domain %4")
-                .arg(shortId, req.scheme, req.caller, req.domain), "warning");
+            QString pathDesc = req.bip32_path.isEmpty()
+                ? QString("domain %1").arg(req.domain)
+                : QString("path %1").arg(req.bip32_path);
+            logActivity(QString("[%1] New %2 sign request from %3 for %4")
+                .arg(shortId, req.scheme, req.caller, pathDesc), "warning");
             m_loggedRequestIds.insert(req.id);
         }
     }
@@ -1107,8 +1146,12 @@ QString KeycardPlugin::approveSign(const QString& jsonArgs)
         return QJsonDocument(result).toJson(QJsonDocument::Compact);
     }
 
-    // Step 2: sign on-card — private key never leaves card
-    QString path = domainToPath(req->domain);
+    // Step 2: sign on-card — private key never leaves card.
+    // bip32_path takes precedence (wallet use case, #149).
+    // Domain-based signing uses 1582' subtree — non-exportable, separate from XPUB (#150).
+    QString path = req->bip32_path.isEmpty()
+                   ? domainToSignPath(req->domain)
+                   : req->bip32_path;
     QByteArray hashBytes = QByteArray::fromHex(req->payloadHash.toUtf8());
 
     uint8_t schemeP2 = (req->scheme == "schnorr") ? Keycard::APDU::P2SignSchnorr

--- a/keycard-core/src/plugin.cpp
+++ b/keycard-core/src/plugin.cpp
@@ -10,6 +10,7 @@
 #include <QDateTime>
 #include <QCryptographicHash>
 #include <QDebug>
+#include <QRegularExpression>
 #include <algorithm>
 #include <sodium.h>
 #include <vector>
@@ -987,10 +988,23 @@ QString KeycardPlugin::requestSign(const QString& jsonArgs)
         err["error"] = "payloadHash must be hex-encoded 32 bytes";
         return QJsonDocument(err).toJson(QJsonDocument::Compact);
     }
-    if (!bip32_path.isEmpty() && !bip32_path.startsWith("m/")) {
-        QJsonObject err;
-        err["error"] = "bip32_path must start with \"m/\"";
-        return QJsonDocument(err).toJson(QJsonDocument::Compact);
+    if (!bip32_path.isEmpty()) {
+        // Validate BIP32 path format: m followed by (/N or /N') segments, N ∈ [0, 2^31-1]
+        static const QRegularExpression kBip32PathRe(
+            R"(^m(/(?:0|[1-9]\d{0,9})'?)*$)"
+        );
+        if (!kBip32PathRe.match(bip32_path).hasMatch()) {
+            QJsonObject err;
+            err["error"] = "bip32_path format invalid — expected m(/N'?)* with decimal indices";
+            return QJsonDocument(err).toJson(QJsonDocument::Compact);
+        }
+        // Block signing with keys from the XPUB/key-export subtree (1581').
+        // Signing subtree is 1582' — keep these namespaces separate per #150.
+        if (bip32_path.startsWith("m/43'/60'/1581'")) {
+            QJsonObject err;
+            err["error"] = "bip32_path may not use the key-export subtree (m/43'/60'/1581')";
+            return QJsonDocument(err).toJson(QJsonDocument::Compact);
+        }
     }
 
     // No card-presence check here — requests are queued before the card is inserted.
@@ -1076,6 +1090,10 @@ QString KeycardPlugin::getPendingSigns()
         obj["timestamp"]   = req.timestamp;
         if (!req.bip32_path.isEmpty())
             obj["bip32_path"] = req.bip32_path;
+        // effective_path is what will actually be signed on-card — shown in approval UI.
+        obj["effective_path"] = req.bip32_path.isEmpty()
+                                ? domainToSignPath(req.domain)
+                                : req.bip32_path;
         pending.append(obj);
 
         if (!m_loggedRequestIds.contains(req.id)) {

--- a/keycard-core/src/plugin.cpp
+++ b/keycard-core/src/plugin.cpp
@@ -12,6 +12,7 @@
 #include <QDebug>
 #include <QRegularExpression>
 #include <algorithm>
+#include <array>
 #include <sodium.h>
 #include <vector>
 
@@ -260,60 +261,26 @@ QString KeycardPlugin::authorize(const QString& pin)
     return QJsonDocument(authResult).toJson(QJsonDocument::Compact);
 }
 
-QString KeycardPlugin::domainToPath(const QString& domain)
+// domainToIndices — SHA256("logos-"||domain), take first 16 bytes as four hardened BIP32 indices.
+// "logos-" prefix for namespace separation; 16 bytes of hash for collision resistance.
+static std::array<uint32_t, 4> domainToIndices(const QString& domain)
 {
-    // EIP-1581: m/43'/60'/1581'/<idx1>'/<idx2>'/<idx3>'/<idx4>'
-    // "logos-" prefix for namespace separation; 16 bytes of hash for collision resistance.
     QByteArray namespaced = ("logos-" + domain).toUtf8();
     unsigned char hash[32];
     crypto_hash_sha256(hash, reinterpret_cast<const unsigned char*>(namespaced.constData()), namespaced.size());
 
-    uint32_t idx1 = (uint32_t(hash[0])  << 24 | uint32_t(hash[1])  << 16 |
-                     uint32_t(hash[2])  << 8  | uint32_t(hash[3]))  & 0x7FFFFFFF;
-    uint32_t idx2 = (uint32_t(hash[4])  << 24 | uint32_t(hash[5])  << 16 |
-                     uint32_t(hash[6])  << 8  | uint32_t(hash[7]))  & 0x7FFFFFFF;
-    uint32_t idx3 = (uint32_t(hash[8])  << 24 | uint32_t(hash[9])  << 16 |
-                     uint32_t(hash[10]) << 8  | uint32_t(hash[11])) & 0x7FFFFFFF;
-    uint32_t idx4 = (uint32_t(hash[12]) << 24 | uint32_t(hash[13]) << 16 |
-                     uint32_t(hash[14]) << 8  | uint32_t(hash[15])) & 0x7FFFFFFF;
-
-    return QString("m/43'/60'/1581'/%1'/%2'/%3'/%4'").arg(idx1).arg(idx2).arg(idx3).arg(idx4);
+    return {{
+        (uint32_t(hash[0])  << 24 | uint32_t(hash[1])  << 16 | uint32_t(hash[2])  << 8 | uint32_t(hash[3]))  & 0x7FFFFFFF,
+        (uint32_t(hash[4])  << 24 | uint32_t(hash[5])  << 16 | uint32_t(hash[6])  << 8 | uint32_t(hash[7]))  & 0x7FFFFFFF,
+        (uint32_t(hash[8])  << 24 | uint32_t(hash[9])  << 16 | uint32_t(hash[10]) << 8 | uint32_t(hash[11])) & 0x7FFFFFFF,
+        (uint32_t(hash[12]) << 24 | uint32_t(hash[13]) << 16 | uint32_t(hash[14]) << 8 | uint32_t(hash[15])) & 0x7FFFFFFF,
+    }};
 }
 
-// validateBip32Path — validates format and bounds of a caller-supplied BIP32 path.
-// Rejects paths where any segment value exceeds 2^31-1 even without the hardened marker,
-// because the vendored signWithPath() parser uses toUInt() and writes the raw uint32 into
-// the APDU — so "2147485229" (= 0x8000062D = 1581') would reach the card unmarked in the
-// string but hardened in the wire encoding.  After bounding all segments we do a string-
-// level subtree block on m/43'/60'/1581' which is now safe (no numeric bypass possible).
-static bool validateBip32Path(const QString& path, QString& outError)
+QString KeycardPlugin::domainToPath(const QString& domain)
 {
-    static const QRegularExpression kSegRe(R"(^(0|[1-9]\d*)('?)$)");
-    if (!path.startsWith("m/")) {
-        outError = QStringLiteral("bip32_path must start with \"m/\"");
-        return false;
-    }
-    const QStringList parts = path.mid(2).split('/');
-    for (const QString& part : parts) {
-        const auto m = kSegRe.match(part);
-        if (!m.hasMatch()) {
-            outError = QStringLiteral("bip32_path format invalid — expected m(/N'?)* with decimal indices");
-            return false;
-        }
-        bool ok = false;
-        const quint64 val = m.captured(1).toULongLong(&ok);
-        if (!ok || val > 2147483647ULL) {  // max BIP32 index = 2^31-1
-            outError = QStringLiteral("bip32_path segment out of range (max 2147483647 per segment)");
-            return false;
-        }
-    }
-    // Block the XPUB/key-export subtree (1581').  Safe after bounds check above —
-    // numeric bypass via raw hardened value (2147485229) is already rejected.
-    if (path.startsWith(QLatin1String("m/43'/60'/1581'"))) {
-        outError = QStringLiteral("bip32_path may not use the key-export subtree (m/43'/60'/1581')");
-        return false;
-    }
-    return true;
+    auto idx = domainToIndices(domain);
+    return QString("m/43'/60'/1581'/%1'/%2'/%3'/%4'").arg(idx[0]).arg(idx[1]).arg(idx[2]).arg(idx[3]);
 }
 
 // domainToSignPath — same hash → indices as domainToPath, but rooted at m/43'/60'/1582'.
@@ -321,20 +288,8 @@ static bool validateBip32Path(const QString& path, QString& outError)
 // keys derived here cannot be exfiltrated via the EXPORT_KEY APDU. (#150)
 QString KeycardPlugin::domainToSignPath(const QString& domain)
 {
-    QByteArray namespaced = ("logos-" + domain).toUtf8();
-    unsigned char hash[32];
-    crypto_hash_sha256(hash, reinterpret_cast<const unsigned char*>(namespaced.constData()), namespaced.size());
-
-    uint32_t idx1 = (uint32_t(hash[0])  << 24 | uint32_t(hash[1])  << 16 |
-                     uint32_t(hash[2])  << 8  | uint32_t(hash[3]))  & 0x7FFFFFFF;
-    uint32_t idx2 = (uint32_t(hash[4])  << 24 | uint32_t(hash[5])  << 16 |
-                     uint32_t(hash[6])  << 8  | uint32_t(hash[7]))  & 0x7FFFFFFF;
-    uint32_t idx3 = (uint32_t(hash[8])  << 24 | uint32_t(hash[9])  << 16 |
-                     uint32_t(hash[10]) << 8  | uint32_t(hash[11])) & 0x7FFFFFFF;
-    uint32_t idx4 = (uint32_t(hash[12]) << 24 | uint32_t(hash[13]) << 16 |
-                     uint32_t(hash[14]) << 8  | uint32_t(hash[15])) & 0x7FFFFFFF;
-
-    return QString("m/43'/60'/1582'/%1'/%2'/%3'/%4'").arg(idx1).arg(idx2).arg(idx3).arg(idx4);
+    auto idx = domainToIndices(domain);
+    return QString("m/43'/60'/1582'/%1'/%2'/%3'/%4'").arg(idx[0]).arg(idx[1]).arg(idx[2]).arg(idx[3]);
 }
 
 QString KeycardPlugin::deriveKey(const QString& domain)
@@ -1025,10 +980,11 @@ QString KeycardPlugin::requestSign(const QString& jsonArgs)
         return QJsonDocument(err).toJson(QJsonDocument::Compact);
     }
     if (!bip32_path.isEmpty()) {
-        QString pathError;
-        if (!validateBip32Path(bip32_path, pathError)) {
+        // Format-only validation — card enforces all policy (0x6985 for restricted paths).
+        static const QRegularExpression kPathRe(R"(^m(/\d+'?){0,10}$)");
+        if (!kPathRe.match(bip32_path).hasMatch()) {
             QJsonObject err;
-            err["error"] = pathError;
+            err["error"] = QStringLiteral("bip32_path format invalid — expected m(/N'?){0,10}");
             return QJsonDocument(err).toJson(QJsonDocument::Compact);
         }
     }

--- a/keycard-core/src/plugin.cpp
+++ b/keycard-core/src/plugin.cpp
@@ -280,6 +280,42 @@ QString KeycardPlugin::domainToPath(const QString& domain)
     return QString("m/43'/60'/1581'/%1'/%2'/%3'/%4'").arg(idx1).arg(idx2).arg(idx3).arg(idx4);
 }
 
+// validateBip32Path — validates format and bounds of a caller-supplied BIP32 path.
+// Rejects paths where any segment value exceeds 2^31-1 even without the hardened marker,
+// because the vendored signWithPath() parser uses toUInt() and writes the raw uint32 into
+// the APDU — so "2147485229" (= 0x8000062D = 1581') would reach the card unmarked in the
+// string but hardened in the wire encoding.  After bounding all segments we do a string-
+// level subtree block on m/43'/60'/1581' which is now safe (no numeric bypass possible).
+static bool validateBip32Path(const QString& path, QString& outError)
+{
+    static const QRegularExpression kSegRe(R"(^(0|[1-9]\d*)('?)$)");
+    if (!path.startsWith("m/")) {
+        outError = QStringLiteral("bip32_path must start with \"m/\"");
+        return false;
+    }
+    const QStringList parts = path.mid(2).split('/');
+    for (const QString& part : parts) {
+        const auto m = kSegRe.match(part);
+        if (!m.hasMatch()) {
+            outError = QStringLiteral("bip32_path format invalid — expected m(/N'?)* with decimal indices");
+            return false;
+        }
+        bool ok = false;
+        const quint64 val = m.captured(1).toULongLong(&ok);
+        if (!ok || val > 2147483647ULL) {  // max BIP32 index = 2^31-1
+            outError = QStringLiteral("bip32_path segment out of range (max 2147483647 per segment)");
+            return false;
+        }
+    }
+    // Block the XPUB/key-export subtree (1581').  Safe after bounds check above —
+    // numeric bypass via raw hardened value (2147485229) is already rejected.
+    if (path.startsWith(QLatin1String("m/43'/60'/1581'"))) {
+        outError = QStringLiteral("bip32_path may not use the key-export subtree (m/43'/60'/1581')");
+        return false;
+    }
+    return true;
+}
+
 // domainToSignPath — same hash → indices as domainToPath, but rooted at m/43'/60'/1582'.
 // 1582' is a non-exportable subtree: chain code export is not permitted there, so signing
 // keys derived here cannot be exfiltrated via the EXPORT_KEY APDU. (#150)
@@ -989,20 +1025,10 @@ QString KeycardPlugin::requestSign(const QString& jsonArgs)
         return QJsonDocument(err).toJson(QJsonDocument::Compact);
     }
     if (!bip32_path.isEmpty()) {
-        // Validate BIP32 path format: m followed by (/N or /N') segments, N ∈ [0, 2^31-1]
-        static const QRegularExpression kBip32PathRe(
-            R"(^m(/(?:0|[1-9]\d{0,9})'?)*$)"
-        );
-        if (!kBip32PathRe.match(bip32_path).hasMatch()) {
+        QString pathError;
+        if (!validateBip32Path(bip32_path, pathError)) {
             QJsonObject err;
-            err["error"] = "bip32_path format invalid — expected m(/N'?)* with decimal indices";
-            return QJsonDocument(err).toJson(QJsonDocument::Compact);
-        }
-        // Block signing with keys from the XPUB/key-export subtree (1581').
-        // Signing subtree is 1582' — keep these namespaces separate per #150.
-        if (bip32_path.startsWith("m/43'/60'/1581'")) {
-            QJsonObject err;
-            err["error"] = "bip32_path may not use the key-export subtree (m/43'/60'/1581')";
+            err["error"] = pathError;
             return QJsonDocument(err).toJson(QJsonDocument::Compact);
         }
     }

--- a/keycard-core/src/plugin.h
+++ b/keycard-core/src/plugin.h
@@ -57,8 +57,8 @@ public:
     // Utility
     Q_INVOKABLE QString hashMessage(const QString& message);  // SHA-256 hex of UTF-8 message
 
-    // Signing request API (#98)
-    Q_INVOKABLE QString requestSign(const QString& jsonArgs); // {"domain","payloadHash","caller","scheme"}
+    // Signing request API (#98, #149, #150)
+    Q_INVOKABLE QString requestSign(const QString& jsonArgs); // {"domain","payloadHash","caller","scheme","bip32_path"?}
     Q_INVOKABLE QString checkSignStatus(const QString& signId);
     Q_INVOKABLE QString getPendingSigns();
     Q_INVOKABLE QString approveSign(const QString& jsonArgs); // {"signId":"...","pin":"..."}
@@ -89,7 +89,8 @@ private:
     void purgeCompletedRequests();
 
     QString mapBridgeStateToSpec(KeycardBridge::State state);
-    QString domainToPath(const QString& domain);
+    QString domainToPath(const QString& domain);      // m/43'/60'/1581' — auth/key-export subtree
+    QString domainToSignPath(const QString& domain);  // m/43'/60'/1582' — signing subtree (#150)
     void logActivity(const QString& message, const QString& level = "info");
     void addActivityToResponse(QJsonObject& response);
 
@@ -105,6 +106,7 @@ private:
         QString payloadHash;  // hex-encoded 32-byte digest
         QString caller;
         QString scheme;       // "ecdsa" or "schnorr"
+        QString bip32_path;   // explicit BIP32 path (#149); if set, overrides domain derivation
         QString status;       // "pending", "complete", "rejected", "failed"
         SecureBuffer signature; // Result — wiped after first read
         QString error;

--- a/keycard-ui/qml/PinEntryScreen.qml
+++ b/keycard-ui/qml/PinEntryScreen.qml
@@ -448,6 +448,19 @@ FocusScope {
                                 Text { text: "scheme"; color: DesignTokens.mutedForeground; font.pixelSize: DesignTokens.fontSizeSmall; font.family: DesignTokens.fontPrimary }
                                 Text { text: root.currentRequest ? (root.currentRequest.scheme || "") : ""; color: DesignTokens.foreground; font.pixelSize: DesignTokens.fontSizeBody; font.family: DesignTokens.fontPrimary }
                             }
+                            Column {
+                                visible: root.currentRequest && !!root.currentRequest.signId
+                                spacing: 4
+                                Text { text: "signing path"; color: DesignTokens.mutedForeground; font.pixelSize: DesignTokens.fontSizeSmall; font.family: DesignTokens.fontPrimary }
+                                Text {
+                                    text: root.currentRequest ? (root.currentRequest.effective_path || "") : ""
+                                    color: DesignTokens.foreground
+                                    font.pixelSize: DesignTokens.fontSizeBody
+                                    font.family: "monospace"
+                                    wrapMode: Text.WrapAnywhere
+                                    width: parent.width
+                                }
+                            }
 
                             Column {
                                 spacing: 4


### PR DESCRIPTION
## Summary

Addresses both issues raised by @bitgamma:

### #150 — Signing keys in non-exportable subtree

Domain-based signing was using `m/43'/60'/1581'` — the XPUB-exportable subtree. Signing keys there can have their chain code exported via `EXPORT_KEY`, which is undesirable.

Fix: add `domainToSignPath()` rooted at `m/43'/60'/1582'` (non-exportable). `approveSign` now uses this for domain-based signing.

Split:
| Subtree | Root | Used for |
|---------|------|----------|
| `1581'` | `m/43'/60'/1581'/<hash-indices>` | `requestAuth` / `deriveKey` / XPUB export — key export is the intent |
| `1582'` | `m/43'/60'/1582'/<hash-indices>` | `approveSign` domain-based — signing only, not exportable |

### #149 — Arbitrary BIP32 paths for signing

Wallet modules need to sign at specific paths (`m/44'/60'/0'/0/0` etc.) not domain-derived ones.

Fix: optional `bip32_path` field in `requestSign` JSON. When present, it takes precedence over domain derivation entirely.

```json
// Domain-based (unchanged)
{"domain":"my-app","payloadHash":"<32B hex>","caller":"wallet","scheme":"ecdsa"}

// Explicit path (new, #149)
{"bip32_path":"m/44'/60'/0'/0/0","payloadHash":"<32B hex>","caller":"wallet","scheme":"ecdsa"}
```

- Validated: must start with `"m/"`
- Either `domain` or `bip32_path` required
- Exposed in `getPendingSigns` response
- Activity log shows `"path m/44'/60'/..."` vs `"domain my-app"` accordingly

## Also fixed

PR #145 comment — corrected the wrong "depth restriction" claim. Root cause of prior 0x6985 failures: wrong TLV tags (`0x81`/`0x83` → `0x80`/`0x82`) and two-step derive+export. No depth restriction exists in the firmware.

## Test plan

- [ ] `requestSign` with `domain` only → signs at `m/43'/60'/1582'/...`
- [ ] `requestSign` with `bip32_path` only → signs at exact path
- [ ] `requestSign` with both → `bip32_path` wins
- [ ] `requestSign` with neither → error returned
- [ ] `bip32_path` not starting with `"m/"` → error returned
- [ ] `getPendingSigns` includes `bip32_path` field when set

@bitgamma — please verify the `1582'` subtree choice is correct and that the `domainToSignPath` / `domainToPath` split matches your intent from #150.

🤖 Fergie via Claude Code