### PR TITLE
feat(#153): emit eventResponse after auth approve/reject

### DIFF
--- a/keycard-core/src/plugin.cpp
+++ b/keycard-core/src/plugin.cpp
@@ -874,6 +874,10 @@ QString KeycardPlugin::authorizeRequest(const QString& authId, const QString& pi
     logActivity("Session closed", "success");
     logActivity(QString("Go back to %1 module to continue").arg(moduleName), "warning");
 
+    // Notify caller module — no key material in event, just authId + caller as signal.
+    // Receiver calls checkAuthStatus(authId) to retrieve the key (one-read-and-drop).
+    emit eventResponse("keycardAuthComplete", {authId, moduleName});
+
     // SECURITY: Do NOT return key here. The only path that hands out
     // the derived key is checkAuthStatus() — one-read-and-drop.
     QJsonObject result;
@@ -905,12 +909,16 @@ QString KeycardPlugin::rejectRequest(const QString& authId)
     }
 
     // Mark as rejected
+    QString caller = targetRequest->caller;
     targetRequest->status = "rejected";
     QString shortId = authId.left(8);
-    logActivity(QString("[%1] Request from %2 declined for domain %3").arg(shortId, targetRequest->caller, targetRequest->domain), "warning");
+    logActivity(QString("[%1] Request from %2 declined for domain %3").arg(shortId, caller, targetRequest->domain), "warning");
 
     // Remove from logged set (cleanup)
     m_loggedRequestIds.remove(authId);
+
+    // Notify caller module — event-driven, no polling needed.
+    emit eventResponse("keycardAuthRejected", {authId, caller});
 
     QJsonObject result;
     result["authId"] = authId;


### PR DESCRIPTION
## Summary

- After `authorizeRequest` succeeds: emit `keycardAuthComplete [authId, caller]`
- After `rejectRequest`: emit `keycardAuthRejected [authId, caller]`
- No key material in events — receiver calls `checkAuthStatus(authId)` to get key

Implements Part 3 of the plan signed off by @bitgamma in #148.

## Test plan

- [ ] Approve auth request → verify `keycardAuthComplete` event fires in beacon/any subscriber
- [ ] Reject auth request → verify `keycardAuthRejected` fires
- [ ] `checkAuthStatus(authId)` after event → returns key, then drops it (one-read-and-drop)
- [ ] No key material visible in event payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)